### PR TITLE
Icons for Dark Mode

### DIFF
--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -278,6 +278,16 @@ var Background = (() => {
         Action.performAction(request.action, "message", instance, items);
       }
     }
+
+    if (request && request.scheme === "dark") {
+      chrome.browserAction.setIcon({
+        path: {
+          "16": "img/16-light.png",
+          "48": "img/48-light.png",
+          "128": "img/128-light.png"
+        }
+      })
+    }
   }
 
   /**

--- a/src/chrome/js/background.js
+++ b/src/chrome/js/background.js
@@ -279,10 +279,13 @@ var Background = (() => {
       }
     }
 
+    // Light icons for dark mode
     if (request && request.scheme === "dark") {
       chrome.browserAction.setIcon({
         path: {
           "16": "img/16-light.png",
+          "24": "img/24-light.png",
+          "32": "img/32-light.png",
           "48": "img/48-light.png",
           "128": "img/128-light.png"
         }

--- a/src/chrome/js/toggle-icon.js
+++ b/src/chrome/js/toggle-icon.js
@@ -1,0 +1,3 @@
+if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+  chrome.runtime.sendMessage({ scheme: "dark" })
+}

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -16,6 +16,12 @@
                 "clear":     { "description": "Clear [x]" },
                 "return":    { "description": "Return To Start" },
                 "auto":      { "description": "Auto Pause / Resume" }},
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["js/toggle-icon.js"]
+    }
+  ],
   "permissions": ["activeTab", "storage"],
   "optional_permissions": ["<all_urls>", "downloads", "declarativeContent"],
   "minimum_chrome_version": "60"

--- a/src/chrome/manifest.json
+++ b/src/chrome/manifest.json
@@ -5,7 +5,7 @@
   "description": "__MSG_description__",
   "version": "6.0",
   "default_locale": "en",
-  "icons": { "16": "img/16-default.png", "48": "img/48-default.png", "128": "img/128-default.png" },
+  "icons": { "16": "img/16-default.png", "24": "img/16-default.png", "32": "img/32-default.png", "48": "img/48-default.png", "128": "img/128-default.png" },
   "browser_action": { "default_title": "__MSG_title__", "default_icon": { "16": "img/16-dark.png", "24": "img/24-dark.png", "32": "img/32-dark.png" }, "default_popup": "html/popup.html" },
   "options_page": "html/options.html",
   "background": { "scripts": ["js/promisify.js", "js/permissions.js", "js/cryptography.js", "js/saves.js", "js/increment-decrement.js", "js/auto.js", "js/action.js", "js/background.js"], "persistent": false },


### PR DESCRIPTION
Fixes #4

**Developer Notes:**
- Followed steps from [this SO question](https://stackoverflow.com/questions/58880234/toggle-chrome-extension-icon-based-on-light-or-dark-mode-browser).
- I am not sure how to build the extension, so have not tested if this actually works.
- Missing icons:
  - `src/chrome/img/24-default.png`
  - `src/chrome/img/32-default.png`
  - `src/chrome/img/48-light.png`
  - `src/chrome/img/128-light.png`
- I am not sure if `"<all_urls>"` permission needs to be moved from the `"optional_permissions"` array into the `"permissions"` array in `src/chrome/manifest.json`.